### PR TITLE
Recursively flatten nested JSON data to a 2 dimensional CSV.

### DIFF
--- a/json2csv.class.php
+++ b/json2csv.class.php
@@ -36,6 +36,20 @@ class JSON2CSVutil{
 			fclose($fileIO);
 		}
 	}
+
+	function flatten2CSV($file){
+		$fileIO = fopen($file, 'w+');
+		foreach ($this->dataArray as $items) {
+			$flatData = array();
+			$fields = new RecursiveIteratorIterator(new RecursiveArrayIterator($items));
+			foreach($fields as $value) {
+  				array_push($flatData, $value);
+			}
+			fputcsv($fileIO, $flatData, ";", '"');
+		}
+		fclose($fileIO);
+	}
+
 	function browserDL($CSVname){
 		if($this->isItNested() || !is_array($this->dataArray)){
 			echo "<h1>JSON is either invalid or has nested elements.</h1>";
@@ -70,6 +84,11 @@ class JSON2CSVutil{
 	function savejsonFile2csv($file, $destFile){
 		$this->JSONfromFile($file);
 		$this->save2CSV($destFile);
+	}
+
+	function flattenjsonFile2csv($file, $destFile){
+		$this->JSONfromFile($file);
+		$this->flatten2CSV($destFile);
 	}
 
 }

--- a/json2csv.class.php
+++ b/json2csv.class.php
@@ -66,6 +66,20 @@ class JSON2CSVutil{
 		}
 	}
 
+	function flattenDL($CSVname){
+		header("Content-Type: text/csv; charset=utf-8");
+		header("Content-Disposition: attachment; filename=$CSVname");
+		$output = fopen("php://output", "w");
+		foreach ($this->dataArray as $items) {
+			$flatData = array();
+			$fields = new RecursiveIteratorIterator(new RecursiveArrayIterator($items));
+			foreach($fields as $value) {
+  				array_push($flatData, $value);
+			}
+			fputcsv($output, $flatData, ";", '"');
+		}
+	}
+
 	private function isItNested(){
 		foreach($this->dataArray as $data){
 			if(is_array($data)){
@@ -79,6 +93,11 @@ class JSON2CSVutil{
 	function savejson2csv($JSONdata, $file){
 		$this->readJSON($JSONdata);
 		$this->save2CSV($file);
+	}
+
+	function flattenjson2csv($JSONdata, $file){
+		$this->readJSON($JSONdata);
+		$this->flatten2CSV($file);
 	}
 
 	function savejsonFile2csv($file, $destFile){

--- a/json2csv.php
+++ b/json2csv.php
@@ -19,7 +19,7 @@ if((isset($_FILES["file"]["type"]) && $_FILES["file"]["type"] != NULL)
 			$filepath = "JSON2.CSV";
 		}
 
-		$JSON2CSV->savejsonFile2csv($arguments["file"], $filepath);
+		$JSON2CSV->flattenjsonFile2csv($arguments["file"], $filepath);
 	}
 	elseif($_FILES["file"]["type"] != NULL){
 		$JSON2CSV->JSONfromFile($_FILES["file"]["tmp_name"]);

--- a/json2csv.php
+++ b/json2csv.php
@@ -23,11 +23,11 @@ if((isset($_FILES["file"]["type"]) && $_FILES["file"]["type"] != NULL)
 	}
 	elseif($_FILES["file"]["type"] != NULL){
 		$JSON2CSV->JSONfromFile($_FILES["file"]["tmp_name"]);
-		$JSON2CSV->browserDL("JSON2.CSV");
+		$JSON2CSV->flattenDL("JSON2.CSV");
 	}
 	elseif($_POST['json'] != NULL){
 		$JSON2CSV->readJSON($_POST['json']);
-		$JSON2CSV->browserDL("JSON2.CSV");
+		$JSON2CSV->flattenDL("JSON2.CSV");
 	}
 }
 else{


### PR DESCRIPTION
I was missing the option to handle nested JSON data. This iterates through the data recursively and flattens all the values into a simple array, which can be then written as CSV. This code also handles normal (not nested) JSONs, and therefore I updated the default action in `json2csv.php` as well.
